### PR TITLE
Add base integration class with abstract handlers

### DIFF
--- a/src/mattermost_mcp_host/base_integration.py
+++ b/src/mattermost_mcp_host/base_integration.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+class BaseIntegration(ABC):
+    """Base class for Mattermost MCP integrations."""
+
+    @abstractmethod
+    async def handle_message(self, post):
+        """Handle incoming messages from Mattermost."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def handle_command(self, channel_id, message_text, user_id, post_id=None, root_id=None):
+        """Handle command messages from Mattermost."""
+        raise NotImplementedError

--- a/src/mattermost_mcp_host/main.py
+++ b/src/mattermost_mcp_host/main.py
@@ -2,6 +2,7 @@ from mattermost_mcp_host.mcp_client import MCPClient
 from mattermost_mcp_host.mattermost_client import MattermostClient
 import mattermost_mcp_host.config as config
 from mattermost_mcp_host.agent import LangGraphAgent
+from mattermost_mcp_host.base_integration import BaseIntegration
 
 import sys
 import asyncio
@@ -39,7 +40,7 @@ def load_server_configs():
         logger.error(f"Error loading server configurations: {str(e)}")
         return {}
 
-class MattermostMCPIntegration:
+class MattermostMCPIntegration(BaseIntegration):
     def __init__(self):
         """Initialize the integration"""
         self.mcp_clients = {}  # Dictionary to store multiple MCP clients


### PR DESCRIPTION
## Summary
- introduce `BaseIntegration` abstract class exposing `handle_message` and `handle_command`
- update `MattermostMCPIntegration` to inherit from `BaseIntegration`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac88f8bd70832bbc0e513ac0eab8ac